### PR TITLE
write JAMS file when ".midi" extension used

### DIFF
--- a/audio_to_midi_melodia.py
+++ b/audio_to_midi_melodia.py
@@ -196,7 +196,7 @@ def audio_to_midi_melodia(infile, outfile, bpm, smooth=0.25, minduration=0.1,
 
     if savejams:
         print("Saving JAMS to disk...")
-        jamsfile = outfile.replace(".mid", ".jams")
+        jamsfile = outfile[:outfile.rfind(".")] + ".jams"
         track_duration = len(data) / float(fs)
         save_jams(jamsfile, notes, track_duration, os.path.basename(infile))
 


### PR DESCRIPTION
old method could create a ".jamsi" file which would fail to save if the extension was longer than '.mid' or a different extension